### PR TITLE
set PA-VM Root device DeleteOnTermination to true so that it is deleted on stack delete

### DIFF
--- a/cfts/paGroupCft.json
+++ b/cfts/paGroupCft.json
@@ -103,6 +103,7 @@
       "Properties" : {
         "ImageId" : { "Fn::FindInMap" : [ "PAVMAMI", { "Ref" : "AWS::Region" }, "AMI"]},
         "InstanceType" : { "Ref" : "paloAltoInstanceType"},
+        "BlockDeviceMappings" : [ { "DeviceName" : "/dev/xvda", "Ebs": { "DeleteOnTermination" : "true" } } ],
         "KeyName" : { "Ref" : "sshKey" },
         "IamInstanceProfile" : { "Ref" : "paGroupInstanceProfile" },
         "NetworkInterfaces": [ { "AssociatePublicIpAddress": "false", "DeviceIndex": "0", "GroupSet": [ { "Ref" : "transitVpcTrustedSecurityGroup" } ], "SubnetId": { "Ref" : "transitVpcMgmtAz1" } } ],
@@ -148,6 +149,7 @@
       "Properties" : {
         "ImageId" : { "Fn::FindInMap" : [ "PAVMAMI", { "Ref" : "AWS::Region" }, "AMI"]},
         "InstanceType" : { "Ref" : "paloAltoInstanceType"},
+        "BlockDeviceMappings" : [ { "DeviceName" : "/dev/xvda", "Ebs": { "DeleteOnTermination" : "true" } } ],
         "KeyName" : { "Ref" : "sshKey" },
         "IamInstanceProfile" : { "Ref" : "paGroupInstanceProfile" },
         "NetworkInterfaces": [ { "AssociatePublicIpAddress": "false", "DeviceIndex": "0", "GroupSet": [ { "Ref" : "transitVpcTrustedSecurityGroup" } ], "SubnetId": { "Ref" : "transitVpcMgmtAz2" } } ],


### PR DESCRIPTION
PA-VM volumes are not deleted when stack is deleted. I suggest that this is changed so that there is no need to manually delete volumes. 