### PR TITLE
added description to cfts/initializeSubscriberAccount.json

### DIFF
--- a/cfts/initializeSubscriberAccount.json
+++ b/cfts/initializeSubscriberAccount.json
@@ -1,5 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Subscribing account stack for Palo Alto Transit VPC",
   "Metadata": {
         "AWS::CloudFormation::Interface": {
           "ParameterGroups": [


### PR DESCRIPTION
The initializeSubscriberAccount.json doesn't have a description, which may make it hard for organizations to know what this stack does. This PR just adds a description.